### PR TITLE
[#4] auth/onboard, posts api 페이지에서 입력받은 값으로 연결

### DIFF
--- a/api/post.ts
+++ b/api/post.ts
@@ -41,7 +41,7 @@ export async function createPost(post: PostPayload) {
             uri: imageUri,
             name: imageUri.split('/').pop() || 'photo.jpg',
             type: 'image/jpeg',
-        } as any); //여기 이해 못함
+        } as any); 
     }
 
     // console.log(`${BASE_URL}/posts`);

--- a/api/post.ts
+++ b/api/post.ts
@@ -3,6 +3,7 @@ import { BASE_URL } from '@env';
 
 export interface PostPayload {
   userId: string;
+  title : string;
   content: string;
   lat: number;
   lon: number;
@@ -22,17 +23,18 @@ export interface OnboardResponse {
 
 
 export async function createPost(post: PostPayload) {
-    const { userId, content, lat, lon, adminDong, imageUri } = post;
+    const { userId, title, content, lat, lon, adminDong, imageUri } = post;
     const formData = new FormData();
 
     console.log("포스트 요청 :", post);
     console.log("포스트 요청 URL :", `${BASE_URL}/posts`);
 
     formData.append('userId', userId);
+    formData.append('title', title);
     formData.append('content', content);
     formData.append('lat', String(lat));
     formData.append('lon', String(lon));
-    // formData.append('adminDong', adminDong);
+    formData.append('adminDong', adminDong);
 
     if (imageUri) {
         formData.append('image',{

--- a/api/post.ts
+++ b/api/post.ts
@@ -42,22 +42,24 @@ export async function createPost(post: PostPayload) {
         } as any); //여기 이해 못함
     }
 
-    console.log(`${BASE_URL}/posts`);
-    const postRes = await axios.post(`${BASE_URL}/posts`, formData);
+    // console.log(`${BASE_URL}/posts`);
+    const postRes = await fetch(`${BASE_URL}/posts`, {
+        method: 'POST',
+        body: formData,
+    // 헤더를 직접 설정하지 마세요!
+    // fetch가 자동으로 "Content-Type: multipart/form-data; boundary=…"를 붙여 줍니다.
+    });
 
-    console.log("포스트 요청 완료");
-    console.log("포스트 응답 :", postRes.data)
+    if (!postRes.ok) {
+        const text = await postRes.text();
+        throw new Error(`HTTP ${postRes.status}: ${text}`);
+    }
+
+    const data=await postRes.json()
+
+    console.log("포스트 응답 :", data)
     
-    // await axios.post(
-    //     `${BASE_URL}/posts`,
-    //     formData,
-    //     {
-
-    //     }
-    // );
-
-    
-    return postRes.data
+    return data
 
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ export default function App() {
     const checkOnboardingStatus = async () => {
       try {
         const userID = await AsyncStorage.getItem('userID');
+
         if (userID === null) {
           setIsFirstLaunch(true);
         } else {
@@ -53,9 +54,21 @@ export default function App() {
     try {
       // const newUserID = 'test-uuid-12345';
 
-      const { adminDong, lat, lon, nickname, userId} = user;
-      await AsyncStorage.setItem('userID', userId);
-      await AsyncStorage.setItem('userNickname', nickname); // 닉네임 저장
+      const { nickname, userId, adminDong, lat, lon} = user;
+      // await AsyncStorage.setItem('userID', userId);
+      // await AsyncStorage.setItem('userNickname', nickname); // 닉네임 저장
+      // await AsyncStorage.setItem('userLat', String(lat)); // 닉네임 저장
+      // await AsyncStorage.setItem('userLon', String(lon)); // 닉네임 저장
+      // await AsyncStorage.setItem('userAdminDong', adminDong); // 닉네임 저장
+
+      await AsyncStorage.multiSet([
+        ['userID',        userId         ],
+        ['userNickname',  nickname       ],
+        ['userLat',       String(lat)    ],
+        ['userLon',       String(lon)    ],
+        ['userAdminDong', adminDong      ],
+      ]);
+
       setIsFirstLaunch(false);
       console.log('New userID saved:', userId);
       console.log('User nickname saved:', nickname);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { TabOneScreen } from './screens/TabOneScreen';
 import { TabTwoScreen } from './screens/TabTwoScreen';
 import { TabThreeScreen } from './screens/TabThreeScreen';
 import OnboardingScreen from './screens/OnboardingScreen';
+import { OnboardResponse } from '../api/post';
 
 const Tab = createBottomTabNavigator();
 
@@ -47,13 +48,16 @@ export default function App() {
   }, []);
 
   // 온보딩 완료 및 닉네임 저장 처리 함수
-  const handleOnboardingComplete = async (nickname: string) => {
+  // const handleOnboardingComplete = async (nickname: string) => {
+  const handleOnboardingComplete = async (user: OnboardResponse) => {
     try {
-      const newUserID = 'test-uuid-12345';
-      await AsyncStorage.setItem('userID', newUserID);
+      // const newUserID = 'test-uuid-12345';
+
+      const { adminDong, lat, lon, nickname, userId} = user;
+      await AsyncStorage.setItem('userID', userId);
       await AsyncStorage.setItem('userNickname', nickname); // 닉네임 저장
       setIsFirstLaunch(false);
-      console.log('New userID saved:', newUserID);
+      console.log('New userID saved:', userId);
       console.log('User nickname saved:', nickname);
     } catch (error) {
       console.error('Error saving userID or nickname:', error);

--- a/src/components/WriteModal.tsx
+++ b/src/components/WriteModal.tsx
@@ -10,27 +10,31 @@ import {
   StyleSheet,
   Platform,
   Alert,
+  TouchableWithoutFeedback,
+  Keyboard
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker'; // ImagePicker 임포트
 
 interface WriteModalProps {
   visible: boolean;
   onClose: () => void;
-  onSave: (title: string, description: string) => void;
+  onSave: (title: string, description: string, imageUri?: string) => void;
 }
 
 export function WriteModal({ visible, onClose, onSave }: WriteModalProps) {
   const [newTitle, setNewTitle] = useState('');
   const [newDescription, setNewDescription] = useState('');
+  const [imageUri, setImageUri] = useState<string|undefined>(undefined);
 
   const handleSave = () => {
     if (newTitle.trim() === '' || newDescription.trim() === '') {
       Alert.alert('알림', '제목과 내용을 모두 입력해주세요.');
       return;
     }
-    onSave(newTitle, newDescription);
+    onSave(newTitle, newDescription, imageUri);
     setNewTitle('');
     setNewDescription('');
+    setImageUri(undefined);
   };
 
   const handleCancel = () => {
@@ -59,6 +63,8 @@ export function WriteModal({ visible, onClose, onSave }: WriteModalProps) {
         const pickedImageUri = result.assets[0].uri;
         console.log('선택된 이미지 URI:', pickedImageUri);
         Alert.alert('사진 첨부', `사진이 선택되었습니다: ${pickedImageUri.substring(0, 30)}...`);
+
+        setImageUri(pickedImageUri);
     } else {
         Alert.alert('알림', '사진 선택이 취소되었습니다.');
     }
@@ -71,40 +77,42 @@ export function WriteModal({ visible, onClose, onSave }: WriteModalProps) {
       visible={visible}
       onRequestClose={onClose}
     >
-      <SafeAreaView style={styles.fullScreenModalContainer}>
-        <View style={styles.modalHeader}>
-          <TouchableOpacity onPress={handleCancel} style={styles.headerButton}>
-            <Text style={styles.headerButtonText}>X</Text>
-          </TouchableOpacity>
-          <TouchableOpacity onPress={handleSave} style={styles.headerButton}>
-            <Text style={styles.headerButtonText}>완료</Text>
-          </TouchableOpacity>
-        </View>
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+        <SafeAreaView style={styles.fullScreenModalContainer}>
+          <View style={styles.modalHeader}>
+            <TouchableOpacity onPress={handleCancel} style={styles.headerButton}>
+              <Text style={styles.headerButtonText}>X</Text>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={handleSave} style={styles.headerButton}>
+              <Text style={styles.headerButtonText}>완료</Text>
+            </TouchableOpacity>
+          </View>
 
-        <View style={styles.modalBody}>
-          <TextInput
-            style={styles.inputTitle}
-            placeholder="제목을 입력하세요"
-            value={newTitle}
-            onChangeText={setNewTitle}
-            maxLength={50}
-          />
-          <TextInput
-            style={styles.inputDescription}
-            placeholder="내용을 입력하세요"
-            value={newDescription}
-            onChangeText={setNewDescription}
-            multiline
-            textAlignVertical="top"
-          />
-        </View>
+          <View style={styles.modalBody}>
+            <TextInput
+              style={styles.inputTitle}
+              placeholder="제목을 입력하세요"
+              value={newTitle}
+              onChangeText={setNewTitle}
+              maxLength={50}
+            />
+            <TextInput
+              style={styles.inputDescription}
+              placeholder="내용을 입력하세요"
+              value={newDescription}
+              onChangeText={setNewDescription}
+              multiline
+              textAlignVertical="top"
+            />
+          </View>
 
-        <View style={styles.modalFooter}>
-          <TouchableOpacity onPress={handleAttachPhoto} style={styles.attachPhotoButton}>
-            <Text style={styles.attachPhotoButtonText}>사진 첨부</Text>
-          </TouchableOpacity>
-        </View>
-      </SafeAreaView>
+          <View style={styles.modalFooter}>
+            <TouchableOpacity onPress={handleAttachPhoto} style={styles.attachPhotoButton}>
+              <Text style={styles.attachPhotoButtonText}>사진 첨부</Text>
+            </TouchableOpacity>
+          </View>
+        </SafeAreaView>
+      </TouchableWithoutFeedback>
     </Modal>
   );
 }

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -2,11 +2,14 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
 import NicknameModal from '../components/NicknameModal'; // 닉네임 모달 임포트
+import { UserPayload,OnboardResponse,createUser } from '../../api/user';
 import { Ionicons } from '@expo/vector-icons'; // Ionicons 임포트 (드롭다운 아이콘용)
+import * as Location from 'expo-location';
 
 // 온보딩 완료 시 호출될 콜백 함수를 위한 Props 타입 정의
 interface OnboardingScreenProps {
-  onFinishOnboarding: (nickname: string) => void; // 닉네임을 인자로 받도록 변경
+  // onFinishOnboarding: (nickname: string) => void; // 닉네임을 인자로 받도록 변경
+  onFinishOnboarding: (user: OnboardResponse) => void; // 유저를 인자로 받도록 변경
 }
 
 const OnboardingScreen: React.FC<OnboardingScreenProps> = ({ onFinishOnboarding }) => {
@@ -16,9 +19,27 @@ const OnboardingScreen: React.FC<OnboardingScreenProps> = ({ onFinishOnboarding 
     setModalVisible(true); // "시작하기" 버튼 클릭 시 닉네임 모달 열기
   };
 
-  const handleNicknameSubmit = (nickname: string) => {
+  // async로 수정
+  const handleNicknameSubmit = async (nickname: string) => {
     setModalVisible(false); // 모달 닫기
-    onFinishOnboarding(nickname); // App.tsx로 닉네임을 전달하며 온보딩 완료 처리
+    // onFinishOnboarding(nickname); // App.tsx로 닉네임을 전달하며 온보딩 완료 처리
+    const { coords } = await Location.getCurrentPositionAsync({});
+
+    try {
+      // 1) 서버에 유저 온보딩 요청
+      const onBoardRes = await createUser({
+        nickname,
+        lat: coords.latitude,
+        lon: coords.longitude
+    });
+
+    // 2) 성공하면 App.tsx로 userId 넘기기
+    // onFinishOnboarding(onBoardRes.userId);
+    onFinishOnboarding(onBoardRes);
+    } catch (e) {
+      console.error('온보딩 API 에러', e);
+      // 실패 처리 UI 띄워도 좋습니다.
+    }
   };
 
   return (

--- a/src/screens/TabOneScreen.tsx
+++ b/src/screens/TabOneScreen.tsx
@@ -4,6 +4,16 @@ import { Text, View, ScrollView, SafeAreaView, StyleSheet, FlatList, Image, Dime
 import { PostPayload,createPost } from '../../api/post';
 import { UserPayload,OnboardResponse,createUser } from '../../api/user';
 import { BASE_URL } from '@env';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+// declare global {
+//   // eslint-disable-next-line no-var
+//   var AsyncStorage: any;
+// }
+// if (__DEV__) { // 개발 모드에서만 실행되도록 보호
+//   global.AsyncStorage = AsyncStorage;
+//   console.log('AsyncStorage object exposed globally for debugging.');
+// }
 
 
 // WriteModal 컴포넌트 임포트
@@ -91,13 +101,38 @@ export function TabOneScreen() {
 // }, []);
 
 
-  const handleAddItem = (title: string, description: string) => {
+  const handleAddItem = async (title: string, description: string) => {
     const newItem = {
       id: String(listData.length + 1),
       image: require('../../assets/adaptive-icon.png'), // 기본 이미지
       title: title,
       description: description,
     };
+
+    const userID = await AsyncStorage.getItem('userID');
+    const userLat = await AsyncStorage.getItem('userLat');
+    const userLon = await AsyncStorage.getItem('userLon');
+    const userAdminDong = await AsyncStorage.getItem('userAdminDong');
+
+    try {
+
+      const newPost = {
+        userId: userID,
+        title: title,
+        content : description,
+        lat: userLat,
+        lon: userLon,
+        imageUri: undefined,
+        adminDong: userAdminDong
+      }
+
+      const postRes = await createPost(newPost);
+      
+
+    } catch(e:any) {
+      console.error(e);
+    }
+
     setListData([newItem, ...listData]); // 새 아이템을 목록 맨 앞에 추가
     setModalVisible(false);
   };

--- a/src/screens/TabOneScreen.tsx
+++ b/src/screens/TabOneScreen.tsx
@@ -46,49 +46,49 @@ export function TabOneScreen() {
   // const [user, setUser] = useState<OnboardResponse>;
   const [modalVisible, setModalVisible] = useState(false);
   const [listData, setListData] = useState(initialData);
-  const [loading, setLoading] = useState(false);
-  const [result,  setResult]  = useState<any>(null);
-  const [error,   setError]   = useState<string|null>(null);
+  // const [loading, setLoading] = useState(false);
+  // const [result,  setResult]  = useState<any>(null);
+  // const [error,   setError]   = useState<string|null>(null);
 
-  const testUser = {
-    nickname: 'skb'+Date.now(),
-    lat: 37.589498,  // 고려대
-    lon: 127.032413
-};
+//   const testUser = {
+//     nickname: 'skb'+Date.now(),
+//     lat: 37.589498,  // 고려대
+//     lon: 127.032413
+// };
 
   // 3) 화면이 열리면 자동 실행
-  useEffect(() => {
-    (async () => {
-      try {
-        // 1) 온보딩
-        const onBoardRes = await createUser(testUser);
-        // setUser(onBoardRes);
+//   useEffect(() => {
+//     (async () => {
+//       try {
+//         // 1) 온보딩
+//         // const onBoardRes = await createUser(testUser);
+//         // setUser(onBoardRes);
 
-        const testPost = {
+//         const testPost = {
 
-          userId:  onBoardRes.userId,
-          content: '이것은 테스트용 글입니다.',
-          lat:      onBoardRes.lat,  
-          lon:      onBoardRes.lon,
-          imageUri: undefined,
-          adminDong: onBoardRes.adminDong
+//           userId:  onBoardRes.userId,
+//           content: '이것은 테스트용 글입니다.',
+//           lat:      onBoardRes.lat,  
+//           lon:      onBoardRes.lon,
+//           imageUri: undefined,
+//           adminDong: onBoardRes.adminDong
 
-        }
+//         }
 
-        // 2) 글 작성
-        const postRes = await createPost(testPost);
-      setResult(postRes);
-    } catch (e: any) {
-      console.error(e.config);
-      console.error(e.message);
-      console.error(e.request);
-      console.error(e.response);
-      setError(e.response?.data?.message || e.message);
-    } finally {
-      setLoading(false);
-    }
-  })();
-}, []);
+//         // 2) 글 작성
+//         const postRes = await createPost(testPost);
+//       setResult(postRes);
+//     } catch (e: any) {
+//       console.error(e.config);
+//       console.error(e.message);
+//       console.error(e.request);
+//       console.error(e.response);
+//       setError(e.response?.data?.message || e.message);
+//     } finally {
+//       setLoading(false);
+//     }
+//   })();
+// }, []);
 
 
   const handleAddItem = (title: string, description: string) => {

--- a/src/screens/TabOneScreen.tsx
+++ b/src/screens/TabOneScreen.tsx
@@ -6,15 +6,6 @@ import { UserPayload,OnboardResponse,createUser } from '../../api/user';
 import { BASE_URL } from '@env';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-// declare global {
-//   // eslint-disable-next-line no-var
-//   var AsyncStorage: any;
-// }
-// if (__DEV__) { // 개발 모드에서만 실행되도록 보호
-//   global.AsyncStorage = AsyncStorage;
-//   console.log('AsyncStorage object exposed globally for debugging.');
-// }
-
 
 // WriteModal 컴포넌트 임포트
 import { WriteModal } from '../components/WriteModal';
@@ -56,55 +47,11 @@ export function TabOneScreen() {
   // const [user, setUser] = useState<OnboardResponse>;
   const [modalVisible, setModalVisible] = useState(false);
   const [listData, setListData] = useState(initialData);
-  // const [loading, setLoading] = useState(false);
-  // const [result,  setResult]  = useState<any>(null);
-  // const [error,   setError]   = useState<string|null>(null);
 
-//   const testUser = {
-//     nickname: 'skb'+Date.now(),
-//     lat: 37.589498,  // 고려대
-//     lon: 127.032413
-// };
-
-  // 3) 화면이 열리면 자동 실행
-//   useEffect(() => {
-//     (async () => {
-//       try {
-//         // 1) 온보딩
-//         // const onBoardRes = await createUser(testUser);
-//         // setUser(onBoardRes);
-
-//         const testPost = {
-
-//           userId:  onBoardRes.userId,
-//           content: '이것은 테스트용 글입니다.',
-//           lat:      onBoardRes.lat,  
-//           lon:      onBoardRes.lon,
-//           imageUri: undefined,
-//           adminDong: onBoardRes.adminDong
-
-//         }
-
-//         // 2) 글 작성
-//         const postRes = await createPost(testPost);
-//       setResult(postRes);
-//     } catch (e: any) {
-//       console.error(e.config);
-//       console.error(e.message);
-//       console.error(e.request);
-//       console.error(e.response);
-//       setError(e.response?.data?.message || e.message);
-//     } finally {
-//       setLoading(false);
-//     }
-//   })();
-// }, []);
-
-
-  const handleAddItem = async (title: string, description: string) => {
+  const handleAddItem = async (title: string, description: string, imageUri?: string) => {
     const newItem = {
       id: String(listData.length + 1),
-      image: require('../../assets/adaptive-icon.png'), // 기본 이미지
+      image: imageUri ? {uri: imageUri} : require('../../assets/adaptive-icon.png'), // 기본 이미지
       title: title,
       description: description,
     };
@@ -114,16 +61,20 @@ export function TabOneScreen() {
     const userLon = await AsyncStorage.getItem('userLon');
     const userAdminDong = await AsyncStorage.getItem('userAdminDong');
 
+    if (!userID)        throw new Error('로그인이 필요합니다.');
+    if (!userLat || !userLon) throw new Error('위치 정보가 없습니다.');
+    if (!userAdminDong) throw new Error('행정동 정보가 없습니다.');
+
     try {
 
       const newPost = {
         userId: userID,
         title: title,
         content : description,
-        lat: userLat,
-        lon: userLon,
-        imageUri: undefined,
-        adminDong: userAdminDong
+        lat: Number(userLat), //asyncstorage에는 string으로 저장되어있음
+        lon: Number(userLon), //asyncstorage에는 string으로 저장되어있음
+        imageUri,
+        adminDong: userAdminDong,
       }
 
       const postRes = await createPost(newPost);


### PR DESCRIPTION
feat:
- OnboardingScreen에서 모달로 입력받은 닉네임과 위치 정보를 POST /api/auth/onboard 엔드포인트로 전송
- WriteModal에서 입력한 제목, 내용, 선택된 이미지 Uri와 AsyncStorage에 저장된 userID, lat/lon, adminDong을 읽어와
  POST /api/posts 엔드포인트로 전송

fix:
- android에서 안되는 이슈 해결 위해 axios -> fetch
- 글 작성 페이지에서 화면의 다른 부분을 누르면 키보드가 내려가도록 수정
